### PR TITLE
TOC Linking now ignores lines with pre-existing links

### DIFF
--- a/build/markdown/mkpdf
+++ b/build/markdown/mkpdf
@@ -41,7 +41,12 @@ function concat () {
 function linkify() {
     LINECOUNT=0
     while IFS='' read -r line || [[ -n "$line"    ]]; do
-        echo "$line" | sed "/^#\{1,3\}\s.*$/s/$/ \{- #section-$LINECOUNT\}/" >> "$2"
+        if ! [[ $line =~ .*\{#section.*\}.* ]]
+        then
+            echo "$line" | sed "/^#\{1,3\}\s.*$/s/$/ \{- #section-$LINECOUNT\}/" >> "$2"
+        else
+            echo "$line" >> "$2"
+        fi
         ((LINECOUNT++))
     done < "$1"
 }
@@ -129,7 +134,6 @@ TOC=()
 tohtml .tmp.before.markdown .tmp.before.html
 
 topdf .tmp.before.html .tmp.html "$OUTPUT"
-
 
 rm .tmp*
 


### PR DESCRIPTION
Links which have already been inserted manually should now continue working