### PR TITLE
Created udev rule to give Z-Stick a consistent name

### DIFF
--- a/hub/exchange/99-usb-serial.rules
+++ b/hub/exchange/99-usb-serial.rules
@@ -1,0 +1,2 @@
+SUBSYSTEM=="tty", ATTRS{idVendor}=="0658",
+ATTRS{idProduct}=="0200", SYMLINK+="zstick"


### PR DESCRIPTION
Installing this UDEV rule will give a consistent device name to the Z-Stick