### PR TITLE
Make Byte max value respect value from hub

### DIFF
--- a/hub/remote/public/core/device/parameter.js
+++ b/hub/remote/public/core/device/parameter.js
@@ -41,7 +41,7 @@ class DeviceParameter extends Component {
                 break;
             case DataType.Byte:
                 this._props.max = Math.min(this._props.max, 255);
-                this._props.min = Math.min(Math.abs(this._props.min), 0);
+                this._props.min = Math.max(Math.abs(this._props.min), 0);
                 /* falls through */
             case DataType.Integer:
                 /* falls through */


### PR DESCRIPTION
The max value for a Byte datatype should be the lower of the specified max and 255, not the max