### PR TITLE
Allows hub to perform a clean shutdown and cache ZWave network configuration

### DIFF
--- a/hub/exchange/src/__main__.py
+++ b/hub/exchange/src/__main__.py
@@ -10,7 +10,7 @@ sys.path.append('../lib')
 from hub        import Hub, Exchange, CLI, args, daemon
 from device     import Device
 from adapter import AriaAdapter, HubAdapter, WemoAdapter, SoftwareAdapter
-#from adapter.zwave_adapter import ZWaveAdapter
+from adapter.zwave_adapter import ZWaveAdapter
 from database import Database
 from ipc import Message
 from device     import SoftwareDeviceFactory


### PR DESCRIPTION
When shutting down the hub via systemd, this will allow the hub to shut down the ZWave network cleanly. Hopefully this allows OpenZWave to cache the network configuration so we can start up faster.