### PR TITLE
Add active session to hub state

### DIFF
--- a/hub/exchange/src/hub/hub.py
+++ b/hub/exchange/src/hub/hub.py
@@ -48,9 +48,9 @@ class Hub(Device):
     @property
     def status (self):
         sessionDict = None
-        if (self.session)
+        if self.session:
             sessionDict = self.session.__dict__
-            
+
         return {
             'version'   : self.version,
             'mode'      : self.mode.value,


### PR DESCRIPTION
Calls to get /hub/state will now return the currently active state